### PR TITLE
SFW-240: version bump and s.pod_target_xcconfig = { 'SWIFT_VERSION' =…

### DIFF
--- a/StanwoodDialog.podspec
+++ b/StanwoodDialog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'StanwoodDialog'
-  s.version          = '1.0.4'
+  s.version          = '1.0.5'
   s.summary          = 'Library to show a rating dialog prompt like the one used in On Air.'
 
   s.description      = <<-DESC
@@ -14,6 +14,7 @@ This allows a more personal approach and dismisses automatically when no interac
   s.source           = { :git => 'https://github.com/stanwood/StanwoodDialog_iOS.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '10.0'
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
 
   s.source_files = 'Stanwood_Dialog_iOS/Classes/**/*.{swift}'
   

--- a/StanwoodDialog.podspec
+++ b/StanwoodDialog.podspec
@@ -14,7 +14,7 @@ This allows a more personal approach and dismisses automatically when no interac
   s.source           = { :git => 'https://github.com/stanwood/StanwoodDialog_iOS.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '10.0'
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
+  s.swift_version = '4.2'
 
   s.source_files = 'Stanwood_Dialog_iOS/Classes/**/*.{swift}'
   


### PR DESCRIPTION
## Description
- Version bump and 
- Added `s.pod_target_xcconfig = { 'SWIFT_VERSION' = > '4.2' }`

## Related links
Jira: [SFW-240](https://stanwood.atlassian.net/browse/SFW-240)